### PR TITLE
Added all `fs` module methods, classes and fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,25 @@ const watch = require('recursive-watch')
 
 const UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 
-const ASYNC_METHODS = ['access', 'exists', 'mkdir', 'lstat', 'readdir',
-                       'readFile', 'rmdir', 'stat', 'unlink', 'writeFile']
-const SYNC_METHODS = ['createReadStream', 'createWriteStream']
+const ASYNC_METHODS = ['access', 'appendFile', 'chmod', 'chown', 'exists',
+                       'lchmod', 'lchown', 'lstat', 'mkdir', 'mkdtemp', 'open',
+                       'readdir', 'readFile', 'rmdir', 'stat', 'truncate',
+                       'unlink', 'utimes', 'writeFile']
+const SYNC_METHODS = ['accessSync', 'appendFileSync', 'chmodSync', 'chownSync',
+                      'createReadStream', 'createWriteStream', 'existsSync',
+                      'lchmodSync', 'lchownSync', 'lstatSync', 'mkdirSync',
+                      'mkdtempSync', 'openSync', 'readdirSync', 'readFileSync',
+                      'rmdirSync', 'statSync', 'truncateSync', 'unlinkSync',
+                      'unwatchFile', 'utimesSync', 'watchFile', 'writeFileSync']
+const FD_METHODS = ['close', 'closeSync', 'fchmod', 'fchmodSync', 'fchown',
+                    'fchownSync', 'fdatasync', 'fdatasyncSync', 'fstat',
+                    'fstatSync', 'fsync', 'fsyncSync', 'ftruncate',
+                    'ftruncateSync', 'futimes', 'futimesSync', 'read',
+                    'readSync', 'write', 'writeSync']
+const BINARY_ASYNC_METHODS = ['link', 'rename', 'symlink']
+const BINARY_SYNC_METHODS = ['linkSync', 'renameSync', 'symlinkSync']
+const UNARY_ASYNC_METHODS = ['readlink', 'realpath']
+const UNARY_SYNC_METHODS = ['readlinkSync', 'realpathSync']
 
 
 class ScopedFS {
@@ -24,28 +40,148 @@ class ScopedFS {
 
 ASYNC_METHODS.forEach(function(name)
 {
+  const func = fs[name]
+  if(!func) return
+
   ScopedFS.prototype[name] = function(path, ...args)
   {
-    path = join(this.base, path)
-    if(!path) return args[args.length-1](new Error('Invalid path'))
+    if(typeof path === 'string')
+    {
+      path = join(this.base, path)
+      if(!path) return args[args.length-1](new Error('Invalid path'))
+    }
 
-    fs[name](path, ...args)
+    return func(path, ...args)
   }
 })
 
 SYNC_METHODS.forEach(function(name)
 {
+  const func = fs[name]
+  if(!func) return
+
   ScopedFS.prototype[name] = function(path, ...args)
   {
-    path = join(this.base, path)
-    if(!path) throw new Error('Invalid path')
+    if(typeof path === 'string')
+    {
+      path = join(this.base, path)
+      if(!path) throw new Error('Invalid path')
+    }
 
-    return fs[name](path, ...args)
+    return func(path, ...args)
+  }
+})
+
+FD_METHODS.forEach(function(name)
+{
+  const func = fs[name]
+  if(!func) return
+
+  ScopedFS.prototype[name] = func
+})
+
+BINARY_ASYNC_METHODS.forEach(function(name)
+{
+  const func = fs[name]
+  if(!func) return
+
+  ScopedFS.prototype[name] = function(oldPath, newPath, ...args)
+  {
+    const cb = args[args.length-1]
+
+    const target = join(this.base, oldPath)
+    if(!target) return cb(new Error('Invalid path'))
+
+    newPath = join(this.base, newPath)
+    if(!newPath) return cb(new Error('Invalid path'))
+
+    if(name !== 'symlink' || path.isAbsolute(oldPath)) oldPath = target
+
+    return func(oldPath, newPath, ...args)
+  }
+})
+
+BINARY_SYNC_METHODS.forEach(function(name)
+{
+  const func = fs[name]
+  if(!func) return
+
+  ScopedFS.prototype[name] = function(oldPath, newPath, ...args)
+  {
+    const target = join(this.base, oldPath)
+    if(!target) throw new Error('Invalid path')
+
+    newPath = join(this.base, newPath)
+    if(!newPath) throw new Error('Invalid path')
+
+    if(name !== 'symlinkSync' || path.isAbsolute(target)) oldPath = target
+
+    return func(oldPath, newPath, ...args)
+  }
+})
+
+UNARY_ASYNC_METHODS.forEach(function(name)
+{
+  const func = fs[name]
+  if(!func) return
+
+  ScopedFS.prototype[name] = function(src, ...args)
+  {
+    const base = this.base
+    src = join(base, src)
+    if(!src) throw new Error('Invalid path')
+
+    const cb = args.pop()
+
+    return func(src, ...args, function(err, target)
+    {
+      if(err) return cb(err)
+
+      if(path.isAbsolute(target))
+      {
+        if(!target.startsWith(base)) return cb(new Error('Invalid target path'))
+
+        target = unjoin(base, target)
+      }
+
+      cb(null, target)
+    })
+  }
+})
+
+UNARY_SYNC_METHODS.forEach(function(name)
+{
+  const func = fs[name]
+  if(!func) return
+
+  ScopedFS.prototype[name] = function(src, ...args)
+  {
+    const base = this.base
+    src = join(base, src)
+    if(!src) throw new Error('Invalid path')
+
+    let target = func(src, ...args)
+
+    if(path.isAbsolute(target))
+    {
+      if(!target.startsWith(base)) throw new Error('Invalid target path')
+
+      target = unjoin(base, target)
+    }
+
+    return target
   }
 })
 
 
 module.exports = ScopedFS
+
+ScopedFS.FSWatcher   = fs.FSWatcher
+ScopedFS.ReadStream  = fs.ReadStream
+ScopedFS.Stats       = fs.Stats
+ScopedFS.WriteStream = fs.WriteStream
+ScopedFS.constants   = fs.constants
+
 
 function join (rootpath, subpath) {
   // make sure they're not using '..' to get outside of rootpath

--- a/index.js
+++ b/index.js
@@ -4,81 +4,14 @@ const watch = require('recursive-watch')
 
 const UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 
+const METHODS = ['createReadStream', 'readFile', 'createWriteStream',
+                 'writeFile', 'mkdir', 'access', 'exists', 'lstat', 'stat',
+                 'readdir', 'unlink', 'rmdir']
+
+
 class ScopedFS {
   constructor (basepath) {
     this.base = basepath
-  }
-
-  createReadStream (name, opts) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.createReadStream(name, opts)
-  }
-
-  readFile (name, ...args) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.readFile(name, ...args)
-  }
-
-  createWriteStream (name, opts) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.createWriteStream(name, opts)
-  }
-
-  writeFile (name, ...args) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.writeFile(name, ...args)
-  }
-
-  mkdir (name, ...args) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.mkdir(name, ...args)
-  }
-
-  access (name, cb) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.access(name, cb)
-  }
-
-  exists (name, cb) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.exists(name, cb)
-  }
-
-  lstat (name, cb) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.lstat(name, cb)
-  }
-
-  stat (name, cb) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.stat(name, cb)
-  }
-
-  readdir (name, cb) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.readdir(name, cb)
-  }
-
-  unlink (name, cb) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.unlink(name, cb)
-  }
-
-  rmdir (name, cb) {
-    name = join(this.base, name)
-    if (!name) return cb(new Error('Invalid path'))
-    return fs.rmdir(name, cb)
   }
 
   watch (name, fn) {
@@ -88,6 +21,18 @@ class ScopedFS {
     })
   }
 }
+
+METHODS.forEach(function(name)
+{
+  ScopedFS.prototype[name] = function(path, ...args)
+  {
+    path = join(this.base, path)
+    if(!path) return args[args.length-1](new Error('Invalid path'))
+    return fs[name](path, ...args)
+  }
+})
+
+
 module.exports = ScopedFS
 
 function join (rootpath, subpath) {

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const watch = require('recursive-watch')
 
 const UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 
-const METHODS = ['createReadStream', 'readFile', 'createWriteStream',
-                 'writeFile', 'mkdir', 'access', 'exists', 'lstat', 'stat',
-                 'readdir', 'unlink', 'rmdir']
+const ASYNC_METHODS = ['access', 'exists', 'mkdir', 'lstat', 'readdir',
+                       'readFile', 'rmdir', 'stat', 'unlink', 'writeFile']
+const SYNC_METHODS = ['createReadStream', 'createWriteStream']
 
 
 class ScopedFS {
@@ -22,12 +22,24 @@ class ScopedFS {
   }
 }
 
-METHODS.forEach(function(name)
+ASYNC_METHODS.forEach(function(name)
 {
   ScopedFS.prototype[name] = function(path, ...args)
   {
     path = join(this.base, path)
     if(!path) return args[args.length-1](new Error('Invalid path'))
+
+    fs[name](path, ...args)
+  }
+})
+
+SYNC_METHODS.forEach(function(name)
+{
+  ScopedFS.prototype[name] = function(path, ...args)
+  {
+    path = join(this.base, path)
+    if(!path) throw new Error('Invalid path')
+
     return fs[name](path, ...args)
   }
 })

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An FS wrapper that keeps all access scoped to a specific folder.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var test = require('tape')
 var fs = require('fs')
 var ScopedFS = require('./index')


### PR DESCRIPTION
This pull-request add all the missing `fs` module methods, classes and its fields including transformation on-the-fly of symlinks, autogenerating them at load to don't need to have duplicated code. I've also fixed the test. Probably the only one missing thing is to return `Error` objects more a-like to the ones raised by the `fs` module instead of the custom "Invalid path" ones.